### PR TITLE
refactor: remove dependency to node:util

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "tinybench": "^2.5.1",
     "ts-node": "^10.9.1",
     "tsup": "^8.0.0",
-    "typescript": "^5.2.2",
+    "typescript": "~5.2.2",
     "zod": "^3.22.4"
   },
   "repository": {

--- a/src/scripts/object/move_unknown_properties.ts
+++ b/src/scripts/object/move_unknown_properties.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-import { inspect } from 'node:util'
-
 /**
  * Options accepts by the output script
  */
@@ -16,6 +14,14 @@ type MovePropertiesOptions = {
   variableName: string
   allowUnknownProperties: boolean
   fieldsToIgnore: string[]
+}
+
+/**
+ * Converts an array of strings to a string representation
+ * like ["foo", "bar"]. Just like node:inspect does.
+ */
+function arrayToString(arr: string[]) {
+  return `[${arr.map((str) => `"${str}"`).join(', ')}]`
 }
 
 /**
@@ -30,5 +36,7 @@ export function defineMoveProperties({
   if (!allowUnknownProperties) {
     return ''
   }
-  return `moveProperties(${variableName}.value, ${variableName}_out, ${inspect(fieldsToIgnore)});`
+
+  const serializedFieldsToIgnore = arrayToString(fieldsToIgnore)
+  return `moveProperties(${variableName}.value, ${variableName}_out, ${serializedFieldsToIgnore});`
 }


### PR DESCRIPTION
In order to make Vine/compiler works in the browser this is the only required change

Since `fieldsToIgnore` can only be an array of string, this simple method should do the trick.